### PR TITLE
Fix Windows build by linking rpcrt4

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,7 +1,7 @@
 CC = x86_64-w64-mingw32-gcc
 CFLAGS = -O2 -Wall -Wextra -std=c11
 INCLUDES = -IC:/SDL2/include -IC:/SDL2_image/include -IC:/SDL2_mixer/include -IC:/SDL2_ttf/include
-LIBS = -static -LC:/SDL2/lib -LC:/SDL2_image/lib -LC:/SDL2_mixer/lib -LC:/SDL2_ttf/lib -lmingw32 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lm -lsetupapi -limm32 -lwinmm -lole32 -loleaut32 -lversion -lgdi32 -luser32
+LIBS = -static -LC:/SDL2/lib -LC:/SDL2_image/lib -LC:/SDL2_mixer/lib -LC:/SDL2_ttf/lib -lmingw32 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf -lm -lsetupapi -limm32 -lwinmm -lole32 -loleaut32 -lversion -lgdi32 -luser32 -lrpcrt4
 
 target = pool.exe
 


### PR DESCRIPTION
## Summary
- Link the rpcrt4 library in the Windows Makefile to resolve missing `UuidCreate` symbol

## Testing
- `make -f Makefile.win` *(fails: x86_64-w64-mingw32-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae083c5cd08326abfafaa7e2ef3e6e